### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ leadtimes:
   step: "03:00:00"
   stop: "09:00:00"
 meta:
-  grids: "{{ workdir }}/grids"
+  grids: "{{ meta.workdir }}/grids"
   levels: &levels [800, 1000]
   workdir: /path/to/workdir
 paths:

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -49,6 +49,8 @@ ignore = [
   "D401",    # non-imperative-mood
   "E731",    # lambda-assignment
   "ERA001",  # commented-out-code
+  "FBT001",  # boolean-type-hint-positional-argument
+  "FBT002",  # boolean-default-value-positional-argument
   "FLY002",  # static-join-to-f-string
   "N813",    # camelcase-imported-as-lowercase
   "PLR0913", # too-many-arguments

--- a/src/wxvx/net.py
+++ b/src/wxvx/net.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import logging
+from functools import cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-import requests
+from requests import Session
+
+TIMEOUT = 30
 
 
 def fetch(taskname: str, url: str, path: Path, headers: dict[str, str] | None = None) -> bool:
     suffix = " %s" % headers.get("Range", "") if headers else ""
     logging.info("%s: Fetching %s%s", taskname, url, suffix)
-    response = requests.get(url, allow_redirects=True, timeout=3, headers=headers or {})
+    response = session().get(url, allow_redirects=True, timeout=TIMEOUT, headers=headers or {})
     expected = HTTPStatus.PARTIAL_CONTENT if headers and "Range" in headers else HTTPStatus.OK
     if response.status_code == expected:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -24,5 +27,10 @@ def fetch(taskname: str, url: str, path: Path, headers: dict[str, str] | None = 
     return False
 
 
+@cache
+def session() -> Session:
+    return Session()
+
+
 def status(url: str) -> int:
-    return requests.head(url, timeout=3).status_code
+    return session().head(url, timeout=TIMEOUT).status_code

--- a/src/wxvx/resources/config.jsonschema
+++ b/src/wxvx/resources/config.jsonschema
@@ -187,7 +187,20 @@
       "additionalProperties": false,
       "properties": {
         "grids": {
-          "type": "string"
+          "additionalProperties": false,
+          "properties": {
+            "baseline": {
+              "type": "string"
+            },
+            "forecast": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "baseline",
+            "forecast"
+          ],
+          "type": "object"
         },
         "run": {
           "type": "string"

--- a/src/wxvx/resources/config.yaml
+++ b/src/wxvx/resources/config.yaml
@@ -21,10 +21,13 @@ leadtimes:
   step: "01:00:00"
   stop: "01:00:00"
 meta:
+  grids: "{{ workdir }}/grids"
   levels: &levels [200, 300, 475, 800, 825, 850, 875, 900, 925, 950, 975, 1000]
   workdir: /path/to/workdir
 paths:
-  grids: "{{ meta.workdir }}/grids"
+  grids:
+    baseline: "{{ meta.grids }}/baseline"
+    forecast: "{{ meta.grids }}/forecast"
   run: "{{ meta.workdir }}/run"
 variables:
   HGT:

--- a/src/wxvx/resources/config.yaml
+++ b/src/wxvx/resources/config.yaml
@@ -21,7 +21,7 @@ leadtimes:
   step: "01:00:00"
   stop: "01:00:00"
 meta:
-  grids: "{{ workdir }}/grids"
+  grids: "{{ meta.workdir }}/grids"
   levels: &levels [200, 300, 475, 800, 825, 850, 875, 900, 925, 950, 975, 1000]
   workdir: /path/to/workdir
 paths:

--- a/src/wxvx/tests/conftest.py
+++ b/src/wxvx/tests/conftest.py
@@ -33,18 +33,40 @@ def check_cf_metadata() -> Callable:
 
 @fixture
 def c(config_data, fakefs):
-    grids, run = [fakefs / x for x in ("grids", "run")]
-    grids.mkdir()
+    grids_baseline, grids_forecast, run = [
+        fakefs / x for x in ("grids/baseline", "grids/forecast", "run")
+    ]
+    grids_baseline.mkdir(parents=True)
+    grids_forecast.mkdir(parents=True)
     run.mkdir()
-    return Config({**config_data, "paths": {"grids": str(grids), "run": str(run)}})
+    return Config(
+        {
+            **config_data,
+            "paths": {
+                "grids": {"baseline": str(grids_baseline), "forecast": str(grids_forecast)},
+                "run": str(run),
+            },
+        }
+    )
 
 
 @fixture
 def c_real_fs(config_data, tmp_path):
-    grids, run = [tmp_path / x for x in ("grids", "run")]
-    grids.mkdir()
+    grids_baseline, grids_forecast, run = [
+        tmp_path / x for x in ("grids/baseline", "grids/forecast", "run")
+    ]
+    grids_baseline.mkdir(parents=True)
+    grids_forecast.mkdir(parents=True)
     run.mkdir()
-    return Config({**config_data, "paths": {"grids": str(grids), "run": str(run)}})
+    return Config(
+        {
+            **config_data,
+            "paths": {
+                "grids": {"baseline": str(grids_baseline), "forecast": str(grids_forecast)},
+                "run": str(run),
+            },
+        }
+    )
 
 
 @fixture
@@ -85,7 +107,10 @@ def config_data():
             "stop": "12:00:00",
         },
         "paths": {
-            "grids": "/path/to/grids",
+            "grids": {
+                "baseline": "/path/to/grids/baseline",
+                "forecast": "/path/to/grids/forecast",
+            },
             "run": "/path/to/run",
         },
         "variables": {

--- a/src/wxvx/tests/test_schema.py
+++ b/src/wxvx/tests/test_schema.py
@@ -178,8 +178,12 @@ def test_schema_paths(config_data, fs, logged):
         assert logged(f"'{key}' is a required property")
     # Additional keys are not allowed:
     assert not ok(with_set(config, 42, "n"))
+    # Some keys have object values:
+    for key in ["grids"]:
+        assert not ok(with_set(config, None, key))
+        assert logged("None is not of type 'object'")
     # Some keys have string values:
-    for key in ["grids", "run"]:
+    for key in ["run"]:
         assert not ok(with_set(config, None, key))
         assert logged("None is not of type 'string'")
 

--- a/src/wxvx/tests/test_schema.py
+++ b/src/wxvx/tests/test_schema.py
@@ -188,6 +188,23 @@ def test_schema_paths(config_data, fs, logged):
         assert logged("None is not of type 'string'")
 
 
+def test_schema_paths_grids(config_data, fs, logged):
+    ok = validator(fs, "properties", "paths", "properties", "grids")
+    config = config_data["paths"]["grids"]
+    # Basic correctness:
+    assert ok(config)
+    # Certain top-level keys are required:
+    for key in ["baseline", "forecast"]:
+        assert not ok(with_del(config, key))
+        assert logged(f"'{key}' is a required property")
+    # Additional keys are not allowed:
+    assert not ok(with_set(config, 42, "n"))
+    # Some keys have string values:
+    for key in ["baseline", "forecast"]:
+        assert not ok(with_set(config, None, key))
+        assert logged("None is not of type 'string'")
+
+
 def test_schema_variables(logged, config_data, fs):
     ok = validator(fs, "properties", "variables")
     config = config_data["variables"]

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -80,7 +80,8 @@ def test_Config(baseline, config_data, cycles, forecast, leadtimes):
     assert obj.cycles == cycles
     assert obj.forecast == forecast
     assert obj.leadtimes == leadtimes
-    assert obj.paths.grids == Path(config_data["paths"]["grids"])
+    assert obj.paths.grids_baseline == Path(config_data["paths"]["grids"]["baseline"])
+    assert obj.paths.grids_forecast == Path(config_data["paths"]["grids"]["forecast"])
     assert obj.paths.run == Path(config_data["paths"]["run"])
     assert obj.variables == config_data["variables"]
     other = types.Config(config_data=config_data)

--- a/src/wxvx/tests/test_util.py
+++ b/src/wxvx/tests/test_util.py
@@ -13,6 +13,17 @@ from wxvx import util
 # Tests
 
 
+def test_atomic(fakefs):
+    path = fakefs / "greeting"
+    assert not path.is_file()
+    msg = "hello"
+    with util.atomic(path) as tmp:
+        assert tmp.is_file()
+        tmp.write_text(msg)
+    assert not tmp.is_file()
+    assert path.read_text() == msg
+
+
 def test_fail(caplog):
     caplog.set_level(logging.INFO)
     with raises(SystemExit) as e:

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -93,7 +93,7 @@ def test_workflow__grib_index_file(c):
     with patch.object(workflow, "fetch") as fetch:
         fetch.side_effect = lambda taskname, url, path: path.touch()  # noqa: ARG005
         workflow._grib_index_file(outdir=c.paths.grids_baseline, url=url)
-    fetch.assert_called_once_with(ANY, url, path)
+    fetch.assert_called_once_with(ANY, url, ANY)
     assert path.exists()
 
 

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -21,16 +21,23 @@ from wxvx.variables import Var
 # Task Tests
 
 
-def test_workflow_grids(c, noop):
-    n_validtimes = len(list(validtimes(c.cycles, c.leadtimes)))
-    n_var_level_pairs = len(list(workflow._varnames_and_levels(c)))
-    n = n_validtimes * n_var_level_pairs
+def test_workflow_grids(c, n_grids, noop):
     with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
-        assert len(refs(workflow.grids(c=c))) == n * 3  # forecast, baseline, and comp grids
-        assert len(refs(workflow.grids(c=c, baseline=True, forecast=True))) == n * 3
-        assert len(refs(workflow.grids(c=c, baseline=True, forecast=False))) == n * 1
-        assert len(refs(workflow.grids(c=c, baseline=False, forecast=True))) == n * 2
+        assert len(refs(workflow.grids(c=c))) == n_grids * 3  # forecast, baseline, and comp grids
+        assert len(refs(workflow.grids(c=c, baseline=True, forecast=True))) == n_grids * 3
+        assert len(refs(workflow.grids(c=c, baseline=True, forecast=False))) == n_grids * 2
+        assert len(refs(workflow.grids(c=c, baseline=False, forecast=True))) == n_grids
         assert len(refs(workflow.grids(c=c, baseline=False, forecast=False))) == 0
+
+
+def test_workflow_grids_baseline(c, n_grids, noop):
+    with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
+        assert len(refs(workflow.grids_baseline(c=c))) == n_grids * 2
+
+
+def test_workflow_grids_forecast(c, n_grids, noop):
+    with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
+        assert len(refs(workflow.grids_forecast(c=c))) == n_grids
 
 
 def test_workflow_plots(c, noop):
@@ -371,6 +378,13 @@ def test__vxvars(c):
 
 
 # Fixtures
+
+
+@fixture
+def n_grids(c):
+    n_validtimes = len(list(validtimes(c.cycles, c.leadtimes)))
+    n_var_level_pairs = len(list(workflow._varnames_and_levels(c)))
+    return n_validtimes * n_var_level_pairs
 
 
 @fixture

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -24,7 +24,7 @@ from wxvx.variables import Var
 def test_workflow_grids(c, noop):
     with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
         val = workflow.grids(c=c)
-    n_validtimes = len(validtimes(c.cycles, c.leadtimes))
+    n_validtimes = len(list(validtimes(c.cycles, c.leadtimes)))
     n_var_level_pairs = len(list(workflow._varnames_and_levels(c)))
     n_grids_per_pair = 3  # forecast grid, baseline grid, comparision grid
     assert len(refs(val)) == n_var_level_pairs * n_validtimes * n_grids_per_pair

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -22,12 +22,15 @@ from wxvx.variables import Var
 
 
 def test_workflow_grids(c, noop):
-    with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
-        val = workflow.grids(c=c)
     n_validtimes = len(list(validtimes(c.cycles, c.leadtimes)))
     n_var_level_pairs = len(list(workflow._varnames_and_levels(c)))
-    n_grids_per_pair = 3  # forecast grid, baseline grid, comparision grid
-    assert len(refs(val)) == n_var_level_pairs * n_validtimes * n_grids_per_pair
+    n = n_validtimes * n_var_level_pairs
+    with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
+        assert len(refs(workflow.grids(c=c))) == n * 3  # forecast, baseline, and comp grids
+        assert len(refs(workflow.grids(c=c, baseline=True, forecast=True))) == n * 3
+        assert len(refs(workflow.grids(c=c, baseline=True, forecast=False))) == n * 1
+        assert len(refs(workflow.grids(c=c, baseline=False, forecast=True))) == n * 2
+        assert len(refs(workflow.grids(c=c, baseline=False, forecast=False))) == 0
 
 
 def test_workflow_plots(c, noop):

--- a/src/wxvx/times.py
+++ b/src/wxvx/times.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, overload
 from wxvx.util import WXVXError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from wxvx.types import Cycles, Leadtimes
 
 # Public
@@ -46,12 +48,12 @@ def tcinfo(tc: TimeCoords, leadtime_digits: int = 3) -> tuple[str, str, str]:
     return (yyyymmdd(dt=tc.cycle), hh(dt=tc.cycle), fmt % (tc.leadtime.total_seconds() // 3600))
 
 
-def validtimes(cycles: Cycles, leadtimes: Leadtimes) -> list[TimeCoords]:
-    pairs = product(
+def validtimes(cycles: Cycles, leadtimes: Leadtimes) -> Iterator[TimeCoords]:
+    for cycle, leadtime in product(
         _cycles(start=cycles.start, step=cycles.step, stop=cycles.stop),
         _leadtimes(leadtimes.start, leadtimes.step, leadtimes.stop),
-    )
-    return sorted({TimeCoords(cycle=cycle, leadtime=leadtime) for cycle, leadtime in pairs})
+    ):
+        yield TimeCoords(cycle=cycle, leadtime=leadtime)
 
 
 def yyyymmdd(dt: datetime) -> str:

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -20,11 +20,13 @@ class Baseline:
 
 class Config:
     def __init__(self, config_data: dict):
+        paths = config_data["paths"]
+        grids = paths["grids"]
         self.baseline = Baseline(**config_data["baseline"])
         self.cycles = Cycles(**config_data["cycles"])
         self.forecast = Forecast(**config_data["forecast"])
         self.leadtimes = Leadtimes(**config_data["leadtimes"])
-        self.paths = Paths(**config_data["paths"])
+        self.paths = Paths(grids["baseline"], grids["forecast"], paths["run"])
         self.variables = config_data["variables"]
 
     KEYS = ("baseline", "cycles", "forecast", "leadtimes", "paths", "variables")
@@ -70,11 +72,13 @@ class Leadtimes:
 
 @dataclass(frozen=True)
 class Paths:
-    grids: Path
+    grids_baseline: Path
+    grids_forecast: Path
     run: Path
 
     def __post_init__(self):
-        _force(self, "grids", Path(self.grids))
+        _force(self, "grids_baseline", Path(self.grids_baseline))
+        _force(self, "grids_forecast", Path(self.grids_forecast))
         _force(self, "run", Path(self.run))
 
 

--- a/src/wxvx/util.py
+++ b/src/wxvx/util.py
@@ -2,16 +2,28 @@ from __future__ import annotations
 
 import logging
 import sys
+from contextlib import contextmanager
 from importlib import resources
 from multiprocessing import Process
 from pathlib import Path
 from subprocess import run
-from typing import NoReturn, cast
+from tempfile import mkstemp
+from typing import TYPE_CHECKING, NoReturn, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 pkgname = __name__.split(".", maxsplit=1)[0]
 
 
 class WXVXError(Exception): ...
+
+
+@contextmanager
+def atomic(path: Path) -> Iterator[Path]:
+    tmp = Path(mkstemp(prefix=path.name, dir=path.parent)[1])
+    yield tmp
+    tmp.rename(path)
 
 
 def fail(msg: str | None = None, *args) -> NoReturn:

--- a/src/wxvx/util.py
+++ b/src/wxvx/util.py
@@ -21,7 +21,7 @@ class WXVXError(Exception): ...
 
 @contextmanager
 def atomic(path: Path) -> Iterator[Path]:
-    tmp = Path(mkstemp(prefix=path.name, dir=path.parent)[1])
+    tmp = Path(mkstemp(prefix=f".{path.name}", dir=path.parent)[1])
     yield tmp
     tmp.rename(path)
 

--- a/src/wxvx/util.py
+++ b/src/wxvx/util.py
@@ -21,6 +21,7 @@ class WXVXError(Exception): ...
 
 @contextmanager
 def atomic(path: Path) -> Iterator[Path]:
+    path.parent.mkdir(parents=True, exist_ok=True)
     tmp = Path(mkstemp(prefix=f".{path.name}", dir=path.parent)[1])
     yield tmp
     tmp.rename(path)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -122,7 +122,7 @@ def _grib_index_file(outdir: Path, url: str):
 @task
 def _grid_grib(c: Config, tc: TimeCoords, var: Var):
     yyyymmdd, hh, leadtime = tcinfo(tc)
-    outdir = c.paths.grids / yyyymmdd / hh / leadtime
+    outdir = c.paths.grids_baseline / yyyymmdd / hh / leadtime
     path = outdir / f"{var}.grib2"
     taskname = "Baseline grid %s" % path
     yield taskname
@@ -139,7 +139,7 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
 @task
 def _grid_nc(c: Config, varname: str, tc: TimeCoords, var: Var):
     yyyymmdd, hh, leadtime = tcinfo(tc)
-    path = c.paths.grids / yyyymmdd / hh / leadtime / f"{var}.nc"
+    path = c.paths.grids_forecast / yyyymmdd / hh / leadtime / f"{var}.nc"
     taskname = "Forecast grid %s" % path
     yield taskname
     yield asset(path, path.is_file)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -39,12 +39,12 @@ def grids(c: Config, baseline: bool = True, forecast: bool = True):
             if forecast:
                 forecast_grid = _grid_nc(c, varname, tc, var)
                 reqs.append(forecast_grid)
-                if c.baseline.compare:
-                    comp_grid = _grid_grib(c, tc, var)
-                    reqs.append(comp_grid)
             if baseline:
                 baseline_grid = _grid_grib(c, TimeCoords(cycle=tc.validtime, leadtime=0), var)
                 reqs.append(baseline_grid)
+                if c.baseline.compare:
+                    comp_grid = _grid_grib(c, tc, var)
+                    reqs.append(comp_grid)
     yield reqs
 
 

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -166,7 +166,6 @@ def _grid_nc(c: Config, varname: str, tc: TimeCoords, var: Var):
     src = da_select(fd.refs, c, varname, tc, var)
     da = da_construct(src)
     ds = ds_construct(c, da, taskname)
-    path.parent.mkdir(parents=True, exist_ok=True)
     with atomic(path) as tmp:
         ds.to_netcdf(tmp, encoding={varname: {"zlib": True, "complevel": 9}})
     logging.info("%s: Wrote %s", taskname, path)
@@ -214,7 +213,6 @@ def _grid_stat_config(
             "tmp_dir": rundir,
         }
     )
-    path.parent.mkdir(parents=True, exist_ok=True)
     with atomic(path) as tmp:
         tmp.write_text(f"{config}\n")
 
@@ -224,7 +222,6 @@ def _polyfile(path: Path, mask: tuple[tuple[float, float]]):
     yield "Poly file %s" % path
     yield asset(path, path.is_file)
     yield None
-    path.parent.mkdir(parents=True, exist_ok=True)
     content = "MASK\n%s\n" % "\n".join(f"{lat} {lon}" for lat, lon in mask)
     with atomic(path) as tmp:
         tmp.write_text(content)
@@ -369,7 +366,6 @@ def _runscript(basepath: Path, content: str):
     yield asset(path, path.is_file)
     yield None
     content = dedent(content).strip()
-    path.parent.mkdir(parents=True, exist_ok=True)
     with atomic(path) as tmp:
         tmp.write_text(f"#!/usr/bin/env bash\n\n{content}\n")
     path.chmod(path.stat().st_mode | S_IEXEC)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from functools import cache
-from http import HTTPStatus
 from itertools import pairwise, product
 from pathlib import Path
 from stat import S_IEXEC
@@ -16,7 +15,7 @@ import yaml
 from iotaa import Node, asset, external, task, tasks
 
 from wxvx.metconf import render
-from wxvx.net import fetch, status
+from wxvx.net import fetch
 from wxvx.times import TimeCoords, tcinfo, validtimes
 from wxvx.types import Source
 from wxvx.util import mpexec
@@ -116,15 +115,8 @@ def _grib_index_file(outdir: Path, url: str):
     taskname = "GRIB index file %s" % path
     yield taskname
     yield asset(path, path.is_file)
-    yield _grib_index_remote(url)
+    yield None
     fetch(taskname, url, path)
-
-
-@external
-def _grib_index_remote(url: str):
-    taskname = "GRIB index remote %s" % url
-    yield taskname
-    yield asset(url, lambda: status(url) == HTTPStatus.OK)
 
 
 @task


### PR DESCRIPTION
- Support writing baseline and forecast grids to separate directories. It may be the case that one set of baseline grids can be used to verify forecasts from multiple models, and such reuse would be more difficult and error prone if baseline and forecast grids are mixed together in single filesystem tree. Or, it may be that the forecast-grid netCDF files, which `wxvx` creates, may need to be deleted and regenerated, in which case having them in their own filesystem tree makes deleting them easy and less error prone.
- Add new tasks `grids_baseline` and `grids_forecast`, which generate only the baseline and forecast grids, respectively. This supports, for example, downloading baseline grids only on a host with internet access, and potentially doing other verification tasks on compute nodes without internet access.
- Use connection pooling via `requests.Session`. This is meant to speed up network requests by reusing an open TCP connection to the remote host instead of opening and closing a connection for every request. Initial, albeit limited, testing showed no benefit, but it's probably best practice anyway.
- Add and use an `atomic` context manager, which provides a temporary file for call-site code to write to, after which the context manager renames the temporary file to the final filename. This is meant to avoid situations where a file might be opened for writing and partially written to before being prematurely terminated (e.g. by a user sending a ctrl-c interrupt, or the system killing the process for exceeding resource-use limits), leaving the file in a corrupt-but-apparently-ready state. Since rename is one of the [things Unix can do atomically](https://rcrowley.org/2010/01/06/things-unix-can-do-atomically.html), this should be an all-or-nothing proposition: Either the final file exists in its complete state, or it doesn't. It's possible that an orphaned temporary file will be left on disk in case of a premature termination, but this is at worst an annoyance requiring cleanup, not a source for corrupt results and potentially cascading errors.